### PR TITLE
chore: fix GoReleaser deprecations and add config validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,18 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.4
+
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: check

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
 
 archives:
   - id: codeowner-archive
-    builds:
+    ids:
       - codeowner
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
@@ -46,21 +46,17 @@ changelog:
       - "^ci:"
       - "^chore:"
 
-brews:
+homebrew_casks:
   - name: codeowner
     repository:
       owner: kevinrobayna
       name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_TAPS_PAT }}"
-    directory: Formula
+    directory: Casks
     homepage: "https://github.com/kevinrobayna/codeowner"
     description: "A CLI tool for working with CODEOWNERS files"
     license: "MIT"
-    install: |
-      bin.install "codeowner"
-    test: |
-      system "#{bin}/codeowner", "version"
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com


### PR DESCRIPTION
## Summary
  - Replace deprecated `archives.builds` with `archives.ids`
  - Migrate `brews` to `homebrew_casks` (with `Casks` directory)
  - Add `goreleaser check` job to CI pipeline to catch config issues early
