### PR TITLE
chore: Add cross-platform test matrix and test summaries to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,37 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['stable', 'oldstable']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ matrix.go-version }}
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
 
       - name: Test
-        run: go test -race -cover ./...
+        run: gotestsum --format github-actions --junitfile test-results.xml -- -race -cover ./...
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.os }}-go${{ matrix.go-version }}
+          path: test-results.xml
+
+      - name: Test summary
+        if: always()
+        uses: test-summary/action@v2
+        with:
+          paths: test-results.xml
 
   lint:
     runs-on: ubuntu-latest
@@ -29,7 +50,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
@@ -43,7 +64,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Check GoReleaser config
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
Test across Go stable/oldstable on Linux, macOS, and Windows. Use gotestsum for inline failure annotations and JUnit XML output, with test-summary/action for step summaries and artifact uploads.