### PR TITLE
fix: Update goreleaser config with proper brew install/test

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,4 @@
 version: 2
-
 builds:
   - id: codeowner
     main: ./cmd/codeowner
@@ -20,12 +19,11 @@ builds:
     goarch:
       - amd64
       - arm64
-
 archives:
   - id: codeowner-archive
-    ids:
+    builds:
       - codeowner
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     format_overrides:
       - goos: windows
         formats:
@@ -33,31 +31,32 @@ archives:
     files:
       - LICENSE*
       - README*
-
 checksum:
-  name_template: "checksums.txt"
-
+  name_template: checksums.txt
 changelog:
   sort: asc
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^ci:"
-      - "^chore:"
-
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+      - '^chore:'
 brews:
   - name: codeowner
     repository:
       owner: kevinrobayna
       name: homebrew-tap
       branch: main
-      token: "{{ .Env.HOMEBREW_TAPS_PAT }}"
+      token: '{{ .Env.HOMEBREW_TAPS_PAT }}'
     directory: Formula
-    homepage: "https://github.com/kevinrobayna/codeowner"
-    description: "A CLI tool for working with CODEOWNERS files"
-    license: "MIT"
+    homepage: https://github.com/kevinrobayna/codeowner
+    description: A CLI tool for working with CODEOWNERS files
+    license: MIT
+    install: |
+      bin.install "codeowner"
+    test: |
+      system "#{bin}/codeowner", "version"
     commit_author:
       name: goreleaserbot
       email: github@kevinrobayna.com
-    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    commit_msg_template: Brew formula update for {{ .ProjectName }} version {{ .Tag }}


### PR DESCRIPTION
Replace deprecated `ids` with `builds` in archives, add install and test blocks to the Homebrew formula, and clean up YAML formatting.